### PR TITLE
Fix linter outputs

### DIFF
--- a/check-docstyle.sh
+++ b/check-docstyle.sh
@@ -11,8 +11,8 @@ GREEN=$(tput bold && tput setaf 2)
 YELLOW=$(tput bold && tput setaf 3)
 
 function prepare_venv() {
-		# we want tests to run on python3.6
-	printf 'checking alias `python3.6` ... '
+	# we want tests to run on python3.6
+	printf 'checking alias `python3.6` ... ' >&2
 	PYTHON=$(which python3.6 2> /dev/null)
 	if [ "$?" -ne "0" ]; then
 		printf "${YELLOW} NOT FOUND ${NORMAL}\n"
@@ -24,9 +24,9 @@ function prepare_venv() {
 		[ "$ec" -ne "0" ] && printf "${RED} NOT FOUND ${NORMAL}\n" && return $ec
 	fi
 
-	printf "${GREEN} OK ${NORMAL}\n"
+	printf "${GREEN} OK ${NORMAL}\n" >&2
 
-	${PYTHON} -m venv "venv" && source venv/bin/activate && pip install pydocstyle
+	${PYTHON} -m venv "venv" && source venv/bin/activate && pip install pydocstyle >&2
 }
 
 # run the pydocstyle for all files that are provided in $1

--- a/check-docstyle.sh
+++ b/check-docstyle.sh
@@ -15,9 +15,9 @@ function prepare_venv() {
 	printf 'checking alias `python3.6` ... ' >&2
 	PYTHON=$(which python3.6 2> /dev/null)
 	if [ "$?" -ne "0" ]; then
-		printf "${YELLOW} NOT FOUND ${NORMAL}\n"
+		printf "${YELLOW} NOT FOUND ${NORMAL}\n" >&2
 
-		printf 'checking alias `python3` ... '
+		printf 'checking alias `python3` ... ' >&2
 		PYTHON=$(which python3 2> /dev/null)
 
 		let ec=$?

--- a/run-linter.sh
+++ b/run-linter.sh
@@ -11,8 +11,8 @@ GREEN=$(tput bold && tput setaf 2)
 YELLOW=$(tput bold && tput setaf 3)
 
 function prepare_venv() {
-		# we want tests to run on python3.6
-	printf 'checking alias `python3.6` ... '
+	# we want tests to run on python3.6
+	printf 'checking alias `python3.6` ... ' >&2
 	PYTHON=$(which python3.6 2> /dev/null)
 	if [ "$?" -ne "0" ]; then
 		printf "${YELLOW} NOT FOUND ${NORMAL}\n"
@@ -24,9 +24,9 @@ function prepare_venv() {
 		[ "$ec" -ne "0" ] && printf "${RED} NOT FOUND ${NORMAL}\n" && return $ec
 	fi
 
-	printf "${GREEN} OK ${NORMAL}\n"
+	printf "${GREEN} OK ${NORMAL}\n" >&2
 
-	${PYTHON} -m venv "venv" && source venv/bin/activate && pip install pycodestyle
+	${PYTHON} -m venv "venv" && source venv/bin/activate && pip install pycodestyle >&2
 }
 
 

--- a/run-linter.sh
+++ b/run-linter.sh
@@ -15,9 +15,9 @@ function prepare_venv() {
 	printf 'checking alias `python3.6` ... ' >&2
 	PYTHON=$(which python3.6 2> /dev/null)
 	if [ "$?" -ne "0" ]; then
-		printf "${YELLOW} NOT FOUND ${NORMAL}\n"
+		printf "${YELLOW} NOT FOUND ${NORMAL}\n" >&2
 
-		printf 'checking alias `python3` ... '
+		printf 'checking alias `python3` ... ' >&2
 		PYTHON=$(which python3 2> /dev/null)
 
 		let ec=$?


### PR DESCRIPTION
The code that parses linter outputs (QA Dashboard) expect quite rigid structure of messages, so let's not break it. On CI, there's no difference between stdout and stderr.