### PR TITLE
Unused parameters fix

### DIFF
--- a/src/toolkit/preprocessing/handlers.py
+++ b/src/toolkit/preprocessing/handlers.py
@@ -154,7 +154,7 @@ class GitHandler(object):
 
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, _exc_type, _exc_val, _exc_tb):
         """Exit the git context manager."""
         os.chdir(self._cwd)
 

--- a/src/toolkit/transformers/classifiers.py
+++ b/src/toolkit/transformers/classifiers.py
@@ -411,7 +411,7 @@ def precision(total: int, correct: int) -> float:
     return float(correct / total)
 
 
-def weighted_precision(y_true, y_pred, weights):  # pylint: disable=unused-argument
+def weighted_precision(_y_true, _y_pred, _weights):  # pylint: disable=unused-argument
     """Calculate weighted precision."""
     raise NotImplementedError("The feature has not been implemented yet."
                               " Sorry for the inconvenience.")

--- a/src/toolkit/transformers/extractors.py
+++ b/src/toolkit/transformers/extractors.py
@@ -226,7 +226,7 @@ class _FeatureExtractor(object):
         return result
 
     @staticmethod
-    def _prev_ngram(features: list, pos: int, n: int, **kwargs):
+    def _prev_ngram(features: list, pos: int, n: int, **_kwargs):
         """Extract contextual information about previous n-gram words."""
         if n == 0:
             return ''
@@ -238,7 +238,7 @@ class _FeatureExtractor(object):
         ]).strip()
 
     @staticmethod
-    def _prev_ngram_tags(features: list, pos: int, n: int, **kwargs):
+    def _prev_ngram_tags(features: list, pos: int, n: int, **_kwargs):
         """Extract contextual information about previous n-gram tags."""
         if n == 0:
             return ''
@@ -250,7 +250,7 @@ class _FeatureExtractor(object):
         ]).strip()
 
     @staticmethod
-    def _next_ngram(features: list, pos: int, n: int, **kwargs):
+    def _next_ngram(features: list, pos: int, n: int, **_kwargs):
         """Extract contextual information about following n-gram words."""
         if n == 0:
             return ''
@@ -262,7 +262,7 @@ class _FeatureExtractor(object):
         ]).strip()
 
     @staticmethod
-    def _next_ngram_tags(features: list, pos: int, n: int, **kwargs):
+    def _next_ngram_tags(features: list, pos: int, n: int, **_kwargs):
         """Extract contextual information about following n-gram tags."""
         if n == 0:
             return ''

--- a/src/toolkit/transformers/feature_hooks.py
+++ b/src/toolkit/transformers/feature_hooks.py
@@ -15,7 +15,7 @@ VOCABULARY = {word.lower(): i for i, word in enumerate(words.words('en'))}
 # Hook Functions
 # --------------
 
-def __has_uppercase(features: list, pos: int, **kwargs) -> bool:
+def __has_uppercase(features: list, pos: int, **_kwargs) -> bool:
     """Return whether the word in `tagged` contains uppercase letter.
 
     :param features: list of tuples (word, tag)
@@ -26,7 +26,7 @@ def __has_uppercase(features: list, pos: int, **kwargs) -> bool:
     return any([w.isupper() for w in word])
 
 
-def __is_alnum(features: list, pos: int, **kwargs) -> bool:
+def __is_alnum(features: list, pos: int, **_kwargs) -> bool:
     """Return whether the word contains only alphanumeric characters.
 
     :param features: list of tuples (word, tag)
@@ -41,7 +41,7 @@ def __vendor_product_match(features: list,
                            pos: int,
                            cve_dict: dict,
                            cve_id: str,
-                           **kwargs) -> bool:
+                           **_kwargs) -> bool:
     """Return whether the given word matches vendor or product of given CVE.
 
     :param features: list of tuples (word, tag)
@@ -82,7 +82,7 @@ def __vendor_product_match(features: list,
     return match
 
 
-def __ver_follows(features: list, pos: int, **kwargs) -> bool:
+def __ver_follows(features: list, pos: int, **_kwargs) -> bool:
     """Return whether the given word is followed by a version string."""
     version_tag = '<VERSION>'
     ver_pos = [
@@ -96,7 +96,7 @@ def __ver_follows(features: list, pos: int, **kwargs) -> bool:
     return any([p > pos for p in ver_pos])
 
 
-def __ver_precedes(features: list, pos: int, **kwargs) -> bool:
+def __ver_precedes(features: list, pos: int, **_kwargs) -> bool:
     """Return whether the given word is preceded by a version string."""
     version_tag = '<VERSION>'
     ver_pos = [
@@ -110,7 +110,7 @@ def __ver_precedes(features: list, pos: int, **kwargs) -> bool:
     return any([p < pos for p in ver_pos])
 
 
-def __ver_pos(features: list, pos: int, **kwargs) -> typing.Union[int, None]:
+def __ver_pos(features: list, pos: int, **_kwargs) -> typing.Union[int, None]:
     """Return version position in the `tagged` w.r.t the given word.
 
     :param features: list of tuples (word, tag)
@@ -126,14 +126,14 @@ def __ver_pos(features: list, pos: int, **kwargs) -> typing.Union[int, None]:
     return min(ver_pos, key=lambda x: abs(x), default=None)
 
 
-def __word_in_dict(features: list, pos: int, **kwargs):
+def __word_in_dict(features: list, pos: int, **_kwargs):
     """Return whether the word is in english dictionary."""
     word, _ = features[pos]
 
     return word.lower() in VOCABULARY
 
 
-def __word_len(features: list, pos: int, cmp=None, limit=3, **kwargs) -> bool:
+def __word_len(features: list, pos: int, cmp=None, limit=3, **_kwargs) -> bool:
     """Compare length of word in `tagged` to the `limit`.
 
     :param features: list of tuples (word, tag)

--- a/src/toolkit/utils.py
+++ b/src/toolkit/utils.py
@@ -16,7 +16,7 @@ class BooleanAction(argparse.Action):
             option_strings, dest, nargs=nargs, **kwargs
         )
 
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(self, _parser, namespace, values, option_string=None):
         """Call BooleanAction instance."""
         setattr(namespace, self.dest,
                 False if option_string.startswith('--no') else True)
@@ -42,7 +42,7 @@ class classproperty(object):  # pylint: disable=invalid-name
         self.__get = fget
         self.__doc = doc
 
-    def __get__(self, instance, cls=None):
+    def __get__(self, _instance, cls=None):
         """Return class property."""
         if cls is None:
             raise AttributeError("instance type not filled")
@@ -50,11 +50,11 @@ class classproperty(object):  # pylint: disable=invalid-name
             raise AttributeError("unreadable attribute")
         return self.__get(cls)
 
-    def __set__(self, inst, value):
+    def __set__(self, _inst, _value):
         """Set class property - DISABLED."""
         raise AttributeError("can't set attribute")
 
-    def __delete__(self, inst):
+    def __delete__(self, _inst):
         """Delete class property - DISABLED."""
         raise AttributeError("can't delete attribute")
 


### PR DESCRIPTION
This is kinda hack to make vulture happy with your code ;) The problem is that unused parameters are seen as unused vars in AST and vulture ignores any `#pylint` `#noqa` etc. specifiers