### PR TITLE
QA script use directories.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ The first script checks the indentation, line lengths, variable names, white spa
 script checks all documentation strings - its presence and format. Please fix any warnings and errors reported by these
 scripts.
 
+List of directories containing source code, that needs to be checked, are stored in a file `directories.txt`
+
 #### Code complexity measurement
 
 The scripts `measure-cyclomatic-complexity.sh` and `measure-maintainability-index.sh` are used to measure code complexity. These scripts can be run w/o any arguments:
@@ -121,6 +123,8 @@ Please note that due to Python's dynamic nature, static code analyzers are likel
 
 Because of this potential problems, only code detected with more than 90% of confidence is reported.
 
+List of directories containing source code, that needs to be checked, are stored in a file `directories.txt`
+
 #### Common issues detection
 
 The script `detect-common-errors.sh` can be used to detect common errors in the repository. This script can be run w/o any arguments:
@@ -130,6 +134,8 @@ The script `detect-common-errors.sh` can be used to detect common errors in the 
 ```
 
 Please note that only semantical problems are reported.
+
+List of directories containing source code, that needs to be checked, are stored in a file `directories.txt`
 
 #### Check for scripts written in BASH
 

--- a/check-docstyle.sh
+++ b/check-docstyle.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-directories="src tests tools"
-separate_files="setup.py"
+IFS=$'\n'
+
+# list of directories with sources to check
+directories=$(cat directories.txt)
+
+# list of separate files to check
+separate_files=$(cat files.txt)
+
 pass=0
 fail=0
 
@@ -75,7 +81,7 @@ done
 echo
 echo "----------------------------------------------------"
 echo "Checking documentation strings in the following files"
-echo $separate_files
+echo "$separate_files"
 echo "----------------------------------------------------"
 
 check_files "$separate_files"

--- a/detect-common-errors.sh
+++ b/detect-common-errors.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
-directories="src tests tools"
-separate_files="setup.py"
+IFS=$'\n'
+
+# list of directories with sources to check
+directories=$(cat directories.txt)
+
+# list of separate files to check
+separate_files=$(cat files.txt)
 
 pass=0
 fail=0

--- a/detect-dead-code.sh
+++ b/detect-dead-code.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
-directories="src tests tools"
-separate_files="setup.py"
+IFS=$'\n'
+
+# list of directories with sources to check
+directories=$(cat directories.txt)
+
+# list of separate files to check
+separate_files=$(cat files.txt)
 
 pass=0
 fail=0

--- a/directories.txt
+++ b/directories.txt
@@ -1,0 +1,3 @@
+src
+tests
+tools

--- a/files.txt
+++ b/files.txt
@@ -1,0 +1,1 @@
+setup.py

--- a/run-linter.sh
+++ b/run-linter.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-directories="src tests tools"
-separate_files="setup.py"
+IFS=$'\n'
+
+# list of directories with sources to check
+directories=$(cat directories.txt)
+
+# list of separate files to check
+separate_files=$(cat files.txt)
+
 pass=0
 fail=0
 

--- a/src/toolkit/transformers/hooks.py
+++ b/src/toolkit/transformers/hooks.py
@@ -24,6 +24,7 @@ class Hook(object):
         foo_hook(x=None)  # prints 'verbosity on'
 
     :param reuse: whether to reuse (share) the Hook
+
     """
 
     __INSTANCES = weakref.WeakSet()


### PR DESCRIPTION
This PR implements the first task in:
https://jira.coreos.com/browse/APPAI-516

Make all QA-related tools more effective and easier to use by developers

    All QA-related scripts needs to be made unified by using external list of directories to check
    All QA-related scripts needs to be moved into separate subdirectory
    QA Dashboard should be updated to use the new scripts (as #1)

JIRA issue for the 1st task:
https://jira.coreos.com/browse/APPAI-481

Currently, several QA-related scripts have the 'source-directories' included in the script body. It would be nice to use separate and central configuration file for this.